### PR TITLE
Minor fixes

### DIFF
--- a/plugin/instacode.vim
+++ b/plugin/instacode.vim
@@ -36,14 +36,14 @@ webbrowser.open('http://instacod.es/?post_code=' + urllib.quote_plus(code) + '&p
 endpython
 	sleep 500m
 	redraw!
-	else 
+	else
 		echomsg "You need to visually select something first"
 	endif
 endfunction
 
-command Instacode :call Instacode()
+command -range Instacode :call Instacode()
 if !hasmapto("<Esc>:Instacode<CR>")
-	vnoremap <leader>ic <Esc>:Instacode<CR>
+	xnoremap <leader>ic <Esc>:Instacode<CR>
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
The -range enables the :Instacode command to work with the visual selection.

`:xnoremap` is preferable to `:vnoremap`, since the latter also works in select mode, and you almost never want that. (http://vimdoc.sourceforge.net/htmldoc/map.html#mapmode-x).
