### PR TITLE
Remove need for python, simplify range functionality

### DIFF
--- a/plugin/instacode.vim
+++ b/plugin/instacode.vim
@@ -36,6 +36,8 @@ function! s:open_url(url)
 			echoerr 'You need to install xdg-open to be able to open urls'
 			return
 		end
+	elseif has('win32') || has('win64')
+		exe '!start rundll32 url.dll,FileProtocolHandler '.url
 	else
 		echoerr 'Don''t know how to open a URL on this system'
 		return

--- a/plugin/instacode.vim
+++ b/plugin/instacode.vim
@@ -14,36 +14,42 @@ let g:loaded_instacode = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-" function by StackOverflow user xolox
-" http://stackoverflow.com/a/6271254
-function! s:get_visual_selection()
-	" Why is this not a built-in Vim script function?!
-	let [lnum1, col1] = getpos("'<")[1:2]
-	let [lnum2, col2] = getpos("'>")[1:2]
-	let lines = getline(lnum1, lnum2)
-	let lines[-1] = lines[-1][: col2 - (&selection == 'inclusive' ? 1 : 2)]
-	let lines[0] = lines[0][col1 - 1:]
-	return join(lines, "\n")
+" Ripped directly from haskellmode.vim
+function! s:url_encode(string)
+	let pat  = '\([^[:alnum:]]\)'
+	let code = '\=printf("%%%02X",char2nr(submatch(1)))'
+	let url  = substitute(a:string,pat,code,'g')
+	return url
 endfunction
 
-function! Instacode()
-	if getpos("'<")[1] > 0
-python << endpython
-import vim, webbrowser, urllib
-code = vim.eval('s:get_visual_selection()')
-filetype = vim.eval('&ft')
-webbrowser.open('http://instacod.es/?post_code=' + urllib.quote_plus(code) + '&post_lang=' + urllib.quote_plus(filetype.title()))
-endpython
-	sleep 500m
-	redraw!
-	else 
-		echomsg "You need to visually select something first"
-	endif
+" Open URLs with the system's default application. Works for both local and
+" remote paths.
+function! s:open_url(url)
+	let url = shellescape(a:url)
+
+	if has('mac')
+		silent call system('open '.url)
+	elseif has('unix')
+		if executable('xdg-open')
+			silent call system('xdg-open '.url.' 2>&1 > /dev/null &')
+		else
+			echoerr 'You need to install xdg-open to be able to open urls'
+			return
+		end
+	else
+		echoerr 'Don''t know how to open a URL on this system'
+		return
+	end
 endfunction
 
-command Instacode :call Instacode()
+function! Instacode(start_lineno, end_lineno)
+	let code = join(getbufline('%', a:start_lineno, a:end_lineno), "\n")
+	call s:open_url('http://instacod.es/?post_code='.s:url_encode(code).'&post_lang='.&ft)
+endfunction
+
+command -range=% Instacode :call Instacode(<line1>, <line2>)
 if !hasmapto("<Esc>:Instacode<CR>")
-	vnoremap <leader>ic <Esc>:Instacode<CR>
+	xnoremap <leader>ic :Instacode<CR>
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
This rewrites a bunch of stuff in order not to use python. It also removes the need to get the visual selection.

For the first part, url encoding is easily implementable in Vim. Apparently. I'll be honest, I'm not entirely sure why the `s:url_encode` function works, but it seems to work quite well.

The other reason to use python, though, is the cross-platform `webbrowser.open`. Vim has nothing like that, but a simple replacement is easy to whip up, as you can see in the `s:open_url` function. Sadly, this doesn't work on Windows, since I don't know how to open urls on Windows. I'm sure there's an easy way using the "start" command, I just don't know it. I'm also not sure how robust relying on `xdg-open` is, but I'm thinking it would be quite easy to add replacements, like `gnome-open` or whatever if people complain.

These are drawbacks, but the benefit is that you don't need to `sleep 500m`, and you don't get weird messages due to python stdout.

As for the visual selection, I've removed the need for it, since `-range=%` provides the ability to take the start and end lines of the selection, defaulting to the start and end lines of the entire buffer. It seems _very_ unlikely to me that someone would actually like to share only half of the first line of a piece of code and/or half of the last one. If nothing else, it might mess with indentation. Seems reasonable to assume that people would like to share a set of lines, and not a random selection.

Given that this pull request improves some things and makes some things worse, I would definitely understand if you reject it. Or, if you want, I could implement only those changes you'd rather have.
